### PR TITLE
ArrayHelper::merge();

### DIFF
--- a/src/PhoneInput.php
+++ b/src/PhoneInput.php
@@ -58,7 +58,7 @@ JS;
      */
     public function run()
     {
-        $options = ArrayHelper::merge($this->defaultOptions, $this->options);
+        $options = ArrayHelper::merge($this->options, $this->defaultOptions);
         if ($this->hasModel()) {
             return Html::activeInput($this->htmlTagType, $this->model, $this->attribute, $options);
         }


### PR DESCRIPTION
Swap position of `$this->options` and `$this->defaultOptions` to give priority to `this->defaultOptions` array, so `this->options` can be overridden.

currently `this->options` overrides the `class` from `'class' => 'form-control form-control-lg'` back to `'class' => 'form-control'`

here is my `defaultOptions`

```
'defaultOptions' => ['autocomplete' => "off", 'class' => 'form-control form-control-lg'],
```